### PR TITLE
Fixed require error

### DIFF
--- a/lib/mongoose-connection-pool/index.js
+++ b/lib/mongoose-connection-pool/index.js
@@ -78,6 +78,9 @@ var ConnectionPool = function(options) {
 
   //Check for any inactive connections once per checkPeriod
   setInterval(cull, opt.checkPeriod);
+  return this;
 };
 
-module.exports = ConnectionPool;
+module.exports = {
+    ConnectionPool: ConnectionPool
+}    


### PR DESCRIPTION
Hello,

I cannot use the library following the example usage :

``` javascript
var ConnectionPool = require('mongoose-connection-pool').ConnectionPool;
```

There are 2 problems:
1. should export "ConnectionPool: ConnectionPool"
2. the function should returh this
